### PR TITLE
Updating formatting of whitespace within `sitemap` generation

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,21 +1,21 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" 
   xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-{{- range where site.RegularPages "Type" "in" site.Params.mainSections -}}
-    <url>
-      <loc>{{ .Permalink }}</loc>
+{{- range where site.RegularPages "Type" "in" site.Params.mainSections }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
       {{- if not .Lastmod.IsZero }}
-        <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
       {{- end }}
-      {{ with .Resources.ByType "image" }}
-        {{ range . }}
-          {{ if ne .Params.exclude_from_sitemap true }}
-          <image:image>
-            <image:loc>{{ .Permalink }}</image:loc>
-          </image:image>
-          {{ end }}
-        {{ end }}
-      {{ end }}
-    </url>
+      {{- with .Resources.ByType "image" }}
+        {{- range . }}
+          {{- if ne .Params.exclude_from_sitemap true }}
+    <image:image>
+      <image:loc>{{ .Permalink }}</image:loc>
+    </image:image>
+          {{- end }}
+        {{- end }}
+      {{- end }}
+  </url>
   {{ end }}
 </urlset>


### PR DESCRIPTION
Just formatting changes, no new functionality. This helps keep the whitespace on the `sitemap.xml` a bit less "extra".