### PR TITLE
Fixing dynamic sizing of images issue with updated Chrome

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -7,28 +7,21 @@
     <div class="row">
       {{ $paginator := .Paginate (where site.RegularPages "Type" "in" "blog") }}
       {{ range $index,$elements:= $paginator.Pages }}
-      {{- /* TODO: Modify existing pages to use resources instead of direct URL's here */ -}}
       {{- /* .Params.image is the front matter for each page, have to get match from what is */ -}}
       {{- /* essentially a `ls images/` within this page's bundle */ -}}
       {{- /* First, let's check for backward compatibility refs */ -}}
-      {{ $image_url := "" }}
-      {{- if and (isset .Params "image") (hasPrefix (.Params.image) "/img") -}}
-        {{ $image_url = (absURL .Params.image) }}
-      {{- /* Second, let's try to find an official resource marker Name for this image */ -}}
-      {{ else if (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ $image_match := (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ with $image_match }}
-          {{ $image_url = $image_match.Permalink }}
-        {{ end }}
-      {{- /* Fallback */ -}}
-      {{ else }}
-        {{ $image_url = (absURL "thumbnail.svg" )}}
+
+      {{ $image := "" }}
+      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
+      {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
+        {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -48,7 +41,7 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,28 +6,25 @@
     <div class="row">
       {{ $paginator := .Paginate (where site.RegularPages "Type" "in" site.Params.mainSections) }}
       {{ range $index,$elements:= $paginator.Pages }}
-      {{- /* TODO: Modify existing pages to use resources instead of direct URL's here */ -}}
       {{- /* .Params.image is the front matter for each page, have to get match from what is */ -}}
       {{- /* essentially a `ls images/` within this page's bundle */ -}}
       {{- /* First, let's check for backward compatibility refs */ -}}
-      {{ $image_url := "" }}
-      {{- if and (isset .Params "image") (hasPrefix (.Params.image) "/img") -}}
-        {{ $image_url = (absURL .Params.image) }}
-      {{- /* Second, let's try to find an official resource marker Name for this image */ -}}
-      {{ else if (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ $image_match := (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ with $image_match }}
-          {{ $image_url = $image_match.Permalink }}
-        {{ end }}
-      {{- /* Fallback */ -}}
-      {{ else }}
-        {{ $image_url = (absURL "thumbnail.svg" )}}
+
+      {{ $image := "" }}
+      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
+      {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
+        {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img srcset='
+            {{- range $sizes }}
+              {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+            {{ end -}}'
+          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -42,7 +39,11 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>

--- a/layouts/partials/mainimage.html
+++ b/layouts/partials/mainimage.html
@@ -1,39 +1,28 @@
 <section>
     <div class="container">
       <div class="post">
-        {{- /* TODO: Modify existing pages to use resources instead of direct URL's here */ -}}
-        {{- /* .Params.image is the front matter for each page, have to get match from what is */ -}}
-        {{- /* essentially a `ls images/` within this page's bundle */ -}}
-        {{- /* First, let's check for backward compatibility refs */ -}}
-        {{ $image_url := "" }}
-        {{ $image_alt := "" }}
-        {{ $image_title := "" }}
-        {{- if and (isset .Params "image") (hasPrefix (.Params.image) "/img") -}}
-        {{- $image_url = (absURL .Params.image) -}}
-        {{- $image_alt = .Params.imagealt }}
-        {{- $image_title = .Params.imagetitle }}
-        {{ else if (.Resources.ByType "image").GetMatch (printf "%s" .Params.image) }}
-        {{ $image_match := (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ with $image_match }}
-        {{ $image_url = $image_match.Permalink }}
-        {{- with index $image_match.Params "alt" }}{{ $image_alt = . }}{{ end -}}
-        {{- with $image_match.Title }}{{ $image_title = . }}{{ end -}}
-        {{ end }}
-        {{- else -}}
-        {{- /* The (former) about page comes through here - TODO? */ -}}
-        {{- /* If no resources or direct img top content is provided, it goes through here */ -}}
-        {{ end -}}
-        {{ if ne $image_url "" }}
-        <img src='{{ $image_url }}' class="img-fluid w-100" alt='{{ $image_alt }}' title='{{ $image_title }}' class='post_thumbnail'>
-        {{ end }}
-            <div class="post-content">
-                <div class="post-date">
-                <span>{{ .PublishDate.Format "02" }}</span>
-                <span>{{ .PublishDate.Format "Jan" }}</span>
-                </div>
-                <h2 class="post-title">{{ .Title }}</h2>
+        {{ $image := "" }}
+        {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
+        {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
+          {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
+          {{- $altText := printf "%s %s %s" .Page.Title .Page.Type .Page.Summary -}}
+          {{- with $image.Params -}}
+            {{- with index $image.Params "alt" }}{{ $altText = . }}{{ end -}}
+          {{- end -}}
+          <img srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+          src='{{ $image.Permalink }}' class="img-fluid w-100" alt='{{ $altText }}' title='{{ $image.Title }}' class='post_thumbnail'>
+          <div class="post-content">
+              <div class="post-date">
+                  <span>{{ .PublishDate.Format "02" }}</span>
+                  <span>{{ .PublishDate.Format "Jan" }}</span>
+              </div>
+              <h2 class="post-title">{{ .Title }}</h2>
                 {{ partial "mainimagetaglinks" . }}
-            </div>
-        </div>
+          </div>
+      </div>
+        {{ end }}
     </div>
 </section>

--- a/layouts/reviews/list.html
+++ b/layouts/reviews/list.html
@@ -7,28 +7,25 @@
     <div class="row">
       {{ $paginator := .Paginate (where site.RegularPages "Type" "in" "reviews") }}
       {{ range $index,$elements:= $paginator.Pages }}
-      {{- /* TODO: Modify existing pages to use resources instead of direct URL's here */ -}}
       {{- /* .Params.image is the front matter for each page, have to get match from what is */ -}}
       {{- /* essentially a `ls images/` within this page's bundle */ -}}
       {{- /* First, let's check for backward compatibility refs */ -}}
-      {{ $image_url := "" }}
-      {{- if and (isset .Params "image") (hasPrefix (.Params.image) "/img") -}}
-        {{ $image_url = (absURL .Params.image) }}
-      {{- /* Second, let's try to find an official resource marker Name for this image */ -}}
-      {{ else if (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ $image_match := (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ with $image_match }}
-          {{ $image_url = $image_match.Permalink }}
-        {{ end }}
-      {{- /* Fallback */ -}}
-      {{ else }}
-        {{ $image_url = (absURL "thumbnail.svg" )}}
+
+      {{ $image := "" }}
+      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
+      {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
+        {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -48,7 +45,11 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -55,8 +55,14 @@
       {{- if not $exclude_gps }}
       {{- if and (ne $image_lat "") (ne $image_long "") }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $image_lat $image_long }}" target="_blank">{{ end -}}
       {{ end }}
-      <img src='{{ $image.Permalink }}' class="lazyload image" 
+      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
+      <img class="lazyload image" 
         style="display:block;max-width:{{ $width }}%;margin:auto;margin-bottom:10px" 
+        srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+        src='{{ $image.Permalink }}'
         alt="{{ $altText }}" 
         title="{{ $image.Title }}"
       />

--- a/layouts/travel/list.html
+++ b/layouts/travel/list.html
@@ -7,28 +7,25 @@
     <div class="row">
       {{ $paginator := .Paginate (where site.RegularPages "Type" "in" "travel") }}
       {{ range $index,$elements:= $paginator.Pages }}
-      {{- /* TODO: Modify existing pages to use resources instead of direct URL's here */ -}}
       {{- /* .Params.image is the front matter for each page, have to get match from what is */ -}}
       {{- /* essentially a `ls images/` within this page's bundle */ -}}
       {{- /* First, let's check for backward compatibility refs */ -}}
-      {{ $image_url := "" }}
-      {{- if and (isset .Params "image") (hasPrefix (.Params.image) "/img") -}}
-        {{ $image_url = (absURL .Params.image) }}
-      {{- /* Second, let's try to find an official resource marker Name for this image */ -}}
-      {{ else if (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ $image_match := (.Resources.ByType "image").GetMatch (.Params.image) }}
-        {{ with $image_match }}
-          {{ $image_url = $image_match.Permalink }}
-        {{ end }}
-      {{- /* Fallback */ -}}
-      {{ else }}
-        {{ $image_url = (absURL "thumbnail.svg" )}}
+
+      {{ $image := "" }}
+      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
+      {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
+        {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -48,7 +45,11 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img src="{{ $image_url }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <img srcset='
+          {{- range $sizes }}
+            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+          {{ end -}}'
+          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>


### PR DESCRIPTION
# Summary
Turns out that I was still holding on to some old `/img` processing rules in these files, which I was using prior to discovering Hugo's resource concept. I spent a lot of time implementing that solution, but then never went back to remove / update the image processing.

Unfortunately this also required me to make the same changes in multiple locations. I should try to make this a bit more standard in the future so that changes get reflected in each from a common location.

This also coincidentally fixes the strange issue I was dealing with when it came to the main image not rendering for the latest Switzerland post. 

This also adds `srcset` to more images, which should help with bandwidth and serving the site more quickly via the CDN.