### PR TITLE
Adding missed comma

### DIFF
--- a/layouts/partials/ldjson.html
+++ b/layouts/partials/ldjson.html
@@ -12,7 +12,7 @@
     "description": "{{ .Site.Params.Meta.Description }}",
     "thumbnailUrl": "{{ $image_url }}",
     "keywords" : [ {{ range $index, $keyword := .Site.Params.Meta.Keywords }}{{ if $index }}, {{ end }}"{{ $keyword }}" {{ end }}],
-    "license": "{{ .Site.Params.Copyright }}"
+    "license": "{{ .Site.Params.Copyright }}",
     "author" : {
         "@type": "Person",
         "name": "{{ .Site.Params.Meta.author }}"


### PR DESCRIPTION
# Summary
My last change missed a comma in the `ldjson` partial. Not sure why the local Hugo binary didn't complain about this when building the project. Perhaps it was only a runtime issue.

Now to see if this automatically runs the GHA job!