### PR TITLE
Adding 10m timeout for GHA and adding metrics output to hugo command

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -95,7 +95,9 @@ jobs:
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/" \
-            --cacheDir "${{ runner.temp }}/.cache/hugo"
+            --cacheDir "${{ runner.temp }}/.cache/hugo" \
+            --templateMetrics \
+            --templateMetricsHints
 
       - name: Cache save
         uses: actions/cache/save@v6

--- a/config.toml
+++ b/config.toml
@@ -206,3 +206,6 @@ link = "plugins/search/search.js"
 [caches]
   [caches.images]
     dir = ':cacheDir/images'
+
+# Set timeout to 5 minutes for GHA image processing
+timeout = "10m"


### PR DESCRIPTION
# Summary
As recommended to me by Gemini, updating the timeout for the `hugo` command in GHA. Image processing is either very hard for GH (I'm likely being throttled in terms of cpu usage) or I just have too many of them. 

I've also added some additional flags to the `hugo` command to output more detail for some profiling to better understand what's happening.