### PR TITLE
Increasing timeout, attempting to increase cache usage / hit rate

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache/restore@v6
         with:
           path: ${{ runner.temp }}/.cache/hugo
-          key: hugo-${{ github.run_id }}
+          key: hugo-${{ github.ref_name }}
           restore-keys: hugo-
 
       - name: Build

--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,9 @@ disableLanguages        = [""]
 enableRobotsTXT         = true
 canonifyURLs            = true
 
+# Set timeout to 10 minutes for GHA image processing
+timeout = "10m"
+
 [pagination]
   pagerSize = 7 # odd number works best here
 
@@ -206,6 +209,3 @@ link = "plugins/search/search.js"
 [caches]
   [caches.images]
     dir = ':cacheDir/images'
-
-# Set timeout to 5 minutes for GHA image processing
-timeout = "10m"


### PR DESCRIPTION
# Summary
A few things to methodically understand GHA better:
- increase timeout to 10 minutes, moving it to the base of the config file (it was assumed under params before)
- Updating the cache location to match against the branch (`ref_name` = `branch`?) to hopefully get a better hit rate

Will need to need trim the image processing behavior.