### PR TITLE
Updating `steps.pages.outputs.base_url` to `steps.pages.outputs.origin`.

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -94,7 +94,7 @@ jobs:
           hugo build \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/" \
+            --baseURL "${{ steps.pages.outputs.origin }}/" \
             --cacheDir "${{ runner.temp }}/.cache/hugo" \
             --templateMetrics \
             --templateMetricsHints


### PR DESCRIPTION
# Summary
Attempting to validate this specific to GHA, i.e., I need the `$img.Permalink` to resolve to `https://tmswfrk.github.io` and not `https://tmswfrk.github.io/bicycle-water-cooler` - the links are already creating a the `bicycle-water-cooler` portion. 

Giving this a go to see if it works the way I want it to!