### PR TITLE
Updating img shortcode to better handle lat and long links

### DIFF
--- a/layouts/partials/imghelper.html
+++ b/layouts/partials/imghelper.html
@@ -1,0 +1,25 @@
+{{- /* layouts/partials/img-helper.html, for help with img shortcode */ -}}
+{{- /* Note that $image.Meta is what Hugo wants after v0.155.0 */ -}}
+{{- /* but $image.Exif is the only place that has non-zero Lat and Long data */ -}}
+{{- /* Will want to follow up on this separately, possibly with a ticket to Hugo */ -}}
+
+{{- /* 1. Initialize variables with default values */ -}}
+{{- $lat := 0.0 -}}
+{{- $long := 0.0 -}}
+
+{{- /* 2. Safely scope into Meta to avoid nil pointer panics */ -}}
+{{- with .Meta -}}
+  {{- $lat = .Lat -}}
+  {{- $long = .Long -}}
+{{- end -}}
+
+{{- /* 3. Fallback for the parser bug */ -}}
+{{- if eq $lat 0.0 -}}
+  {{- with .Exif -}}
+    {{- $lat = .Lat -}}
+    {{- $long = .Long -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* 4. Return the dictionary */ -}}
+{{- return dict "lat" $lat "long" $long -}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -39,12 +39,8 @@
         {{- $image = ($resource_page.Resources.ByType "image").GetMatch (index $image_names 0) -}}
       {{ end }}
       {{- /* Build up Latitude and Longitude URLs for Google Maps */ -}}
-        {{- $image_lat := "" -}}
-        {{- $image_long := "" -}}
-        {{- with $image.Meta -}}
-          {{- $image_lat = .Lat -}}
-          {{- $image_long = .Long -}}
-        {{- end -}}
+      {{- $coords := partial "imghelper.html" $image -}}
+
       {{- $altText := printf "%s %s %s" $page.Title $page.Type $page.Summary -}}
       {{- $width := printf "%d" 100 -}}
       {{- with $image.Params -}}
@@ -53,7 +49,7 @@
       {{- end -}}
       {{- $exclude_gps := index $image.Params "exclude_gps" }}
       {{- if not $exclude_gps }}
-      {{- if and (ne $image_lat "") (ne $image_long "") }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $image_lat $image_long }}" target="_blank">{{ end -}}
+      {{- if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $coords.lat $coords.long }}" target="_blank">{{ end -}}
       {{ end }}
       {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
       <img class="lazyload image" 
@@ -66,7 +62,7 @@
         alt="{{ $altText }}" 
         title="{{ $image.Title }}"
       />
-      {{- if and (ne $image_lat "") (ne $image_long "") }}</a>{{ end -}}
+      {{- if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}</a>{{ end -}}
       
       {{- else -}}
     <div class="grid">
@@ -82,35 +78,28 @@
         
         <div class= "{{$class}}">
           {{ with $image -}}
-
             {{- /* Build up Latitude and Longitude URLs for Google Maps */ -}}
-            {{- $image_lat := "" -}}
-            {{- $image_long := "" -}}
-            {{- with $image.Meta -}}
-              {{- $image_lat = .Lat -}}
-              {{- $image_long = .Long -}}
-            {{- end -}}
-            
-              {{- /* Only show Google Maps URL if we have both latitude and longitude values */ -}}
-              {{- $exclude_gps := index $image.Params "exclude_gps" }}
-              {{- if not $exclude_gps }}
-              {{- if and (ne $image_lat "") (ne $image_long "") }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $image_lat $image_long }}" target="_blank">{{ end }}
-              {{ end }}
-                <img class="pogoimage" style="margin-top:0;margin-bottom:10px;" sizes="{{ printf "%svw" (string (div 60 $numberOfCols) ) }}"
-                  srcset='
-                  {{- range $sizes }}
-                    {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-                  {{ end -}}'
-                  src="{{ ($image.Resize "640x").Permalink }}"
-                  class="lazyload image"
-                  {{- $altText := printf "%s %s %s" $page.Title $page.Type $page.Summary -}}
-                  {{- with $image.Params -}}
-                  {{ $altText = index $image.Params "alt" }}
-                  {{ end -}}
-                  alt="{{- $altText }}"
-                  title="{{- $image.Title }}"
-                >
-              {{ if and (ne $image_lat "") (ne $image_long "") }}</a>{{ end -}}
+            {{- $coords := partial "imghelper.html" $image -}}
+            {{- /* Only show Google Maps URL if we have both latitude and longitude values */ -}}
+            {{- $exclude_gps := index $image.Params "exclude_gps" }}
+            {{- if not $exclude_gps }}
+            {{- if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $coords.lat $coords.long }}" target="_blank">{{ end }}
+            {{ end }}
+              <img class="pogoimage" style="margin-top:0;margin-bottom:10px;" sizes="{{ printf "%svw" (string (div 60 $numberOfCols) ) }}"
+                srcset='
+                {{- range $sizes }}
+                  {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+                {{ end -}}'
+                src="{{ ($image.Resize "640x").Permalink }}"
+                class="lazyload image"
+                {{- $altText := printf "%s %s %s" $page.Title $page.Type $page.Summary -}}
+                {{- with $image.Params -}}
+                {{ $altText = index $image.Params "alt" }}
+                {{ end -}}
+                alt="{{- $altText }}"
+                title="{{- $image.Title }}"
+              >
+            {{ if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}</a>{{ end -}}
           {{ end -}}
         </div>
     {{- end -}}


### PR DESCRIPTION
# Summary
Accidentally broke this processing when attempting to resolve this warning message: 
```
WARN  deprecated: Image.Exif was deprecated in Hugo v0.155.0 and will be removed in a future release. Use Image.Meta, see https://gohugo.io/content-management/image-processing/#meta
```
Unfortunately it seems that the `.Lat` and `.Long` entries from within the `$image.Meta.Lat` and `$image.Meta.Long` attributes are simply zeros. No amount of configuration changes that I've found so far properly retrieve them from the exif data that's long been part of these images. 

Utilizing Gemini a bit, I attempted to add a few entries to my `config.yaml` but with to no avail: 
```
[imaging]
  [imaging.exif]
    disableLatLong = false
    includeFields = '.*'
```
...as an example. And yes, I removed `public/` and `resources/` before rebuilding the app to verify this. 

There may be another solution here, but I'll have to look more into it later, there's a possible regression here in the Hugo source code (I guess a new image processing library was included and it's far stricter in how it retrieves exif data from source files).

Additionally, I pulled out the coordinate extraction logic into a separate partial so that the `{{img}}` shortcode could use it rather than needing to copy/paste it twice. I'd like to do more of this to simplify this html flow, but i'll do that separately and maybe one step at a time.