### PR TITLE
Changing back baseURL param for GHA (and small img change I had staged)

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -94,7 +94,7 @@ jobs:
           hugo build \
             --gc \
             --minify \
-            --baseURL "${{ steps.pages.outputs.origin }}/" \
+            --baseURL "${{ steps.pages.outputs.base_url }}/" \
             --cacheDir "${{ runner.temp }}/.cache/hugo" \
             --templateMetrics \
             --templateMetricsHints

--- a/content/blog/Introspective/Thoughts_on_Zwift/index.md
+++ b/content/blog/Introspective/Thoughts_on_Zwift/index.md
@@ -69,6 +69,7 @@ resources:
   title: "Who's a good bike rider? You're a good bike rider!"
   params:
     alt: "GIF of a dog riding a bicycle down a street"
+    width: 50
 - src: '*/trex.png'
   name: "trex"
   title: "Rawr"


### PR DESCRIPTION
# Summary
I'm trying to better understand how the baseURL param is to be used here during GHA only.

Using a local pi editor, this should be specified as `https://tmswfrk.github.io/bicycle-water-cooler` to reflect the baseURL for this website if it is to be hosted in github pages.

This also includes a small staged change to change a single image's size. I expect I'll have more of these later.