### PR TITLE
Making relative URLs false to no longer conflict with baseURL param in GHA

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseurl                 = "https://www.bicyclewatercooler.com/"
-relativeurls            = true
+relativeurls            = false
 DefaultContentLanguage  = "en"
 title                    = "Bicycle Water Cooler"
 theme                   = "persian"


### PR DESCRIPTION
# Summary
From the local AI response to this, it seems that using a relative path here is getting confused by the `--baseURL` param being supplied by GHA.

```
The issue with your images is being caused by the relativeurls = true setting in your config.toml.

 Here is what's happening:

 1. How Hugo generates the path: Your image srcset in the shortcodes/partials uses .RelPermalink, which generates a root-relative path. Because you are now building with a baseURL that includes a subpath
    (https://tmswfrk.github.io/bicycle-water-cooler/), .RelPermalink outputs /bicycle-water-cooler/travel/....
 2. How relativeurls breaks it: When relativeurls = true, Hugo parses your generated HTML and attempts to rewrite any link starting with / to make it relative to the current file's location. If a post is 3 directories deep
    (travel/2024/the-big-mountains...), Hugo rewrites the link by prepending ../../../ and stripping the leading slash, resulting in ../../../bicycle-water-cooler/travel/....
 3. The browser resolution: When the browser sees ../../../bicycle-water-cooler/... from a page at https://tmswfrk.github.io/bicycle-water-cooler/travel/2024/..., it navigates up three directories to the domain root
    (tmswfrk.github.io) and then appends the path, effectively requesting tmswfrk.github.io/bicycle-water-cooler/bicycle-water-cooler/.... This duplicates the repository name and breaks the image load.

 (The src attribute works perfectly because it uses .Permalink, which generates an absolute https://... URL. Hugo's relativeURLs rewrite logic ignores absolute URLs.)

 What you need to change:
 In your config.toml, simply change relativeurls to false (or remove the line entirely, as false is the default)
```