### PR TITLE
Utilized Gemini to prefer AVIF over JPEG, using Hugo processes to do so

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,8 +9,8 @@ disableLanguages        = [""]
 enableRobotsTXT         = true
 canonifyURLs            = true
 
-# Set timeout to 10 minutes for GHA image processing
-timeout = "10m"
+# Set timeout to 30 minutes for heavy AVIF image processing on first run
+timeout = "30m"
 
 [pagination]
   pagerSize = 7 # odd number works best here
@@ -70,6 +70,12 @@ timeout = "10m"
   socialShare           = ["facebook", "reddit", "linkedin", "email"]
 
   description = "Welcome to the Bicycle Water Cooler, your online water cooler conversation about all things cycling. Come join the conversation!"
+
+[params.imaging]
+  format = "avif"
+  quality = "q65"
+  fallbackQuality = "q85"
+  sizes = [360, 480, 800, 1200]
 
   [params.meta]
     description         = "Bicycle Water Cooler Blog | Biking, Travel, Tech, Reviews"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,20 +11,31 @@
       {{- /* First, let's check for backward compatibility refs */ -}}
 
       {{ $image := "" }}
-      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
       {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
         {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
+      {{- $imgFormat := site.Params.imaging.format | default "avif" -}}
+      {{- $imgQuality := site.Params.imaging.quality | default "q65" -}}
+      {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
+      {{- $validSizes := partial "image_sizes.html" $image -}}
 
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img srcset='
-            {{- range $sizes }}
-              {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-            {{ end -}}'
-          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+              {{- range $validSizes }}
+                {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+              {{ end -}}'
+            />
+            <img srcset='
+              {{- range $validSizes }}
+                {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+              {{ end -}}'
+            src="{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          </picture>
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -39,11 +50,18 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-          {{ end -}}'
-          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            />
+            <img srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            src="{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          </picture>
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>

--- a/layouts/partials/image_sizes.html
+++ b/layouts/partials/image_sizes.html
@@ -1,0 +1,13 @@
+{{- $image := . -}}
+{{- $validSizes := slice -}}
+{{- if $image -}}
+  {{- range site.Params.imaging.sizes -}}
+    {{- if le . $image.Width -}}
+      {{- $validSizes = $validSizes | append . -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not (in $validSizes $image.Width) -}}
+    {{- $validSizes = $validSizes | append $image.Width -}}
+  {{- end -}}
+{{- end -}}
+{{- return $validSizes -}}

--- a/layouts/partials/mainimage.html
+++ b/layouts/partials/mainimage.html
@@ -2,18 +2,32 @@
     <div class="container">
       <div class="post">
         {{ $image := "" }}
-        {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
         {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
           {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
+
+          {{- $imgFormat := site.Params.imaging.format | default "avif" -}}
+          {{- $imgQuality := site.Params.imaging.quality | default "q65" -}}
+          {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
+          {{- $validSizes := partial "image_sizes.html" $image -}}
+
           {{- $altText := printf "%s %s %s" .Page.Title .Page.Type .Page.Summary -}}
           {{- with $image.Params -}}
             {{- with index $image.Params "alt" }}{{ $altText = . }}{{ end -}}
           {{- end -}}
-          <img srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-          {{ end -}}'
-          src='{{ $image.Permalink }}' class="img-fluid w-100" alt='{{ $altText }}' title='{{ $image.Title }}' class='post_thumbnail'>
+
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}' />
+
+            <img srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            src='{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}' 
+            class="img-fluid w-100 post_thumbnail" alt='{{ $altText }}' title='{{ $image.Title }}'>
+          </picture>
           <div class="post-content">
               <div class="post-date">
                   <span>{{ .PublishDate.Format "02" }}</span>

--- a/layouts/reviews/list.html
+++ b/layouts/reviews/list.html
@@ -12,20 +12,31 @@
       {{- /* First, let's check for backward compatibility refs */ -}}
 
       {{ $image := "" }}
-      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
       {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
         {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
+      {{- $imgFormat := site.Params.imaging.format | default "avif" -}}
+      {{- $imgQuality := site.Params.imaging.quality | default "q65" -}}
+      {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
+      {{- $validSizes := partial "image_sizes.html" $image -}}
 
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-          {{ end -}}'
-          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            />
+            <img srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            src="{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          </picture>
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -45,11 +56,18 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-          {{ end -}}'
-          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            />
+            <img srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            src="{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          </picture>
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -51,17 +51,27 @@
       {{- if not $exclude_gps }}
       {{- if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $coords.lat $coords.long }}" target="_blank">{{ end -}}
       {{ end }}
-      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
-      <img class="lazyload image" 
-        style="display:block;max-width:{{ $width }}%;margin:auto;margin-bottom:10px" 
-        srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
+      {{- $imgFormat := site.Params.imaging.format | default "avif" -}}
+      {{- $imgQuality := site.Params.imaging.quality | default "q65" -}}
+      {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
+      {{- $validSizes := partial "image_sizes.html" $image -}}
+      <picture>
+        <source type="image/{{ $imgFormat }}" srcset='
+          {{- range $validSizes }}
+            {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
           {{ end -}}'
-        src='{{ $image.Permalink }}'
-        alt="{{ $altText }}" 
-        title="{{ $image.Title }}"
-      />
+        />
+        <img class="lazyload image"
+          style="display:block;max-width:{{ $width }}%;margin:auto;margin-bottom:10px"
+          srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+          src='{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}'
+          alt="{{ $altText }}"
+          title="{{ $image.Title }}"
+        />
+      </picture>
       {{- if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}</a>{{ end -}}
       
       {{- else -}}
@@ -72,10 +82,14 @@
     {{- /* front matter and then use that Name defined there to pass in here */ -}}
     {{- range $image_names -}}
         {{- $image_resource_name := . -}}
-        {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
         {{- $resource_page := $page.Page -}}
         {{- $image := ($resource_page.Resources.ByType "image").GetMatch $image_resource_name -}}
         
+        {{- $imgFormat := site.Params.imaging.format | default "avif" -}}
+        {{- $imgQuality := site.Params.imaging.quality | default "q65" -}}
+        {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
+        {{- $validSizes := partial "image_sizes.html" $image -}}
+
         <div class= "{{$class}}">
           {{ with $image -}}
             {{- /* Build up Latitude and Longitude URLs for Google Maps */ -}}
@@ -85,20 +99,27 @@
             {{- if not $exclude_gps }}
             {{- if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}<a href="{{ printf "https://www.google.com/maps/search/?api=1&query=%f,%f" $coords.lat $coords.long }}" target="_blank">{{ end }}
             {{ end }}
-              <img class="pogoimage" style="margin-top:0;margin-bottom:10px;" sizes="{{ printf "%svw" (string (div 60 $numberOfCols) ) }}"
-                srcset='
-                {{- range $sizes }}
-                  {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-                {{ end -}}'
-                src="{{ ($image.Resize "640x").Permalink }}"
-                class="lazyload image"
-                {{- $altText := printf "%s %s %s" $page.Title $page.Type $page.Summary -}}
-                {{- with $image.Params -}}
-                {{ $altText = index $image.Params "alt" }}
-                {{ end -}}
-                alt="{{- $altText }}"
-                title="{{- $image.Title }}"
-              >
+              <picture>
+                <source type="image/{{ $imgFormat }}" sizes="{{ printf "%svw" (string (div 60 $numberOfCols) ) }}" srcset='
+                  {{- range $validSizes }}
+                    {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+                  {{ end -}}'
+                />
+                <img class="pogoimage" style="margin-top:0;margin-bottom:10px;" sizes="{{ printf "%svw" (string (div 60 $numberOfCols) ) }}"
+                  srcset='
+                  {{- range $validSizes }}
+                    {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+                  {{ end -}}'
+                  src="{{ ($image.Resize (printf "640x %s" $fallbackQuality)).Permalink }}"
+                  class="lazyload image"
+                  {{- $altText := printf "%s %s %s" $page.Title $page.Type $page.Summary -}}
+                  {{- with $image.Params -}}
+                  {{ $altText = index $image.Params "alt" }}
+                  {{ end -}}
+                  alt="{{- $altText }}"
+                  title="{{- $image.Title }}"
+                >
+              </picture>
             {{ if and (ne $coords.lat 0.0) (ne $coords.long 0.0) }}</a>{{ end -}}
           {{ end -}}
         </div>

--- a/layouts/travel/list.html
+++ b/layouts/travel/list.html
@@ -12,20 +12,31 @@
       {{- /* First, let's check for backward compatibility refs */ -}}
 
       {{ $image := "" }}
-      {{- $sizes := (slice  "360" "480" "800" "1200" ) -}}
       {{ if (.Resources.ByType "image").GetMatch (.Params.image) }}
         {{ $image = (.Resources.ByType "image").GetMatch (.Params.image)}}
       {{ end }}
+
+      {{- $imgFormat := site.Params.imaging.format | default "avif" -}}
+      {{- $imgQuality := site.Params.imaging.quality | default "q65" -}}
+      {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
+      {{- $validSizes := partial "image_sizes.html" $image -}}
 
       {{ if eq $index 0}}
       <div class="col-12 mb-4">
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-          {{ end -}}'
-          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            />
+            <img srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            src="{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          </picture>
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>
@@ -45,11 +56,18 @@
       <div class="col-md-6 mb-4">
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
-          <img srcset='
-          {{- range $sizes }}
-            {{- ($image.Resize (printf "%sx" .)).RelPermalink }} {{ (printf "%sw" .) }},
-          {{ end -}}'
-          src="{{ $image.Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          <picture>
+            <source type="image/{{ $imgFormat }}" srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            />
+            <img srcset='
+            {{- range $validSizes }}
+              {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
+            {{ end -}}'
+            src="{{ ($image.Resize (printf "%vx %s" (index $validSizes 0) $fallbackQuality)).Permalink }}" class="img-fluid w-100" alt="{{ .Title }}">
+          </picture>
           <div class="post-content">
             <div class="post-date">
               <span>{{ .PublishDate.Format "02" }}</span>


### PR DESCRIPTION
# Summary
In general, AVIF is a more modern standard for image compression and usage across the internet. But it's not supported by every browser. 

These changes prefer using AVIF along with `<picture>` to better conform with HTML5 standards while also falling back to traditional support via `<img>` and JPEG files. 

I think this increases the payload unfortunately to the CDN, but i'll be tackling that separately if it's an issue - to help counter it, I've updated the GHA timeout to 30m just in case, and hoping that caching will eventually assist here.

I also made sure to standardize and centralize the sizes that we prepopulate for each image's srcset parameter so that it's not spread across a bunch of separate files.