### PR TITLE
Adding in max sizing considerations to help out when on slow connection

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -25,12 +25,12 @@
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 1200px) 100vw, 1200px" srcset='
               {{- range $validSizes }}
                 {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
               {{ end -}}'
             />
-            <img srcset='
+            <img sizes="(max-width: 1200px) 100vw, 1200px" srcset='
               {{- range $validSizes }}
                 {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
               {{ end -}}'
@@ -51,12 +51,12 @@
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 768px) 100vw, 50vw" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
             />
-            <img srcset='
+            <img sizes="(max-width: 768px) 100vw, 50vw" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'

--- a/layouts/partials/mainimage.html
+++ b/layouts/partials/mainimage.html
@@ -16,12 +16,12 @@
           {{- end -}}
 
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 1200px) 100vw, 1200px" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}' />
 
-            <img srcset='
+            <img sizes="(max-width: 1200px) 100vw, 1200px" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'

--- a/layouts/reviews/list.html
+++ b/layouts/reviews/list.html
@@ -26,12 +26,12 @@
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 1200px) 100vw, 1200px" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
             />
-            <img srcset='
+            <img sizes="(max-width: 1200px) 100vw, 1200px" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
@@ -57,12 +57,12 @@
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 768px) 100vw, 50vw" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
             />
-            <img srcset='
+            <img sizes="(max-width: 768px) 100vw, 50vw" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -56,7 +56,7 @@
       {{- $fallbackQuality := site.Params.imaging.fallbackQuality | default "q85" -}}
       {{- $validSizes := partial "image_sizes.html" $image -}}
       <picture>
-        <source type="image/{{ $imgFormat }}" srcset='
+        <source type="image/{{ $imgFormat }}" sizes="(max-width: {{ $width }}%) 100vw, {{ $width }}vw" srcset='
           {{- range $validSizes }}
             {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
           {{ end -}}'
@@ -64,6 +64,7 @@
         <img class="lazyload image"
           loading="lazy"
           decoding="async"
+          sizes="(max-width: {{ $width }}%) 100vw, {{ $width }}vw"
           style="display:block;max-width:{{ $width }}%;margin:auto;margin-bottom:10px"
           srcset='
             {{- range $validSizes }}

--- a/layouts/travel/list.html
+++ b/layouts/travel/list.html
@@ -26,12 +26,12 @@
         <div class="post dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 1200px) 100vw, 1200px" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
             />
-            <img srcset='
+            <img sizes="(max-width: 1200px) 100vw, 1200px" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
@@ -57,12 +57,12 @@
         <div class="post post-sm dimmable linkable-div">
           <a href="{{ .Permalink }}" target="_self" style="display: block;"><span class="linkable-span"></span></a>
           <picture>
-            <source type="image/{{ $imgFormat }}" srcset='
+            <source type="image/{{ $imgFormat }}" sizes="(max-width: 768px) 100vw, 50vw" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s %s" . $imgQuality $imgFormat)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'
             />
-            <img srcset='
+            <img sizes="(max-width: 768px) 100vw, 50vw" srcset='
             {{- range $validSizes }}
               {{- ($image.Resize (printf "%vx %s" . $fallbackQuality)).RelPermalink }} {{ (printf "%vw" .) }},
             {{ end -}}'


### PR DESCRIPTION
# Summary
I have been on a slow connection today and noticed that my website was loading VERY slow in both Azure and in the newly deployed GHP location. So I had Gemini look at the image srcsets again to make sure the browser was selecting the correct images to download.
```
All the sizes attributes have been added! Here is how the browser will now behave:

 1. For the hero image and the first post in lists (the full-width images):
    I added sizes="(max-width: 1200px) 100vw, 1200px". This tells the browser: "If the screen is smaller than 1200px, the image will take up 100% of the screen width, so download an image
    size that matches the screen. But if the screen is massive, the layout maxes out at 1200px, so don't download anything larger than that."

 2. For the grid layout posts (the smaller side-by-side cards):
    I added sizes="(max-width: 768px) 100vw, 50vw". This tells the browser: "On a mobile phone (under 768px), these cards stack vertically and take up 100% of the screen. But on a
    tablet/laptop, they sit side-by-side and only take up 50% of the screen." The browser will now do the math and download a much smaller image for laptop users.

 3. For the inline markdown images (layouts/shortcodes/img.html):
    I added dynamic logic based on how you wrote the shortcode! The sizes attribute was already configured correctly for the image grids <image img1 img2 img3>, but for single images, it
    was missing. I added sizes="(max-width: {{ $width }}%) 100vw, {{ $width }}vw", which hooks into your existing shortcode logic (so if you tell Hugo the image should be width=50 in the
    markdown, the browser will know to only download a file big enough to fill 50% of the screen).

 The result: When you open this site on your slow Wi-Fi on a laptop, the browser will now see the sizes="... 50vw" rule for the grid cards, immediately jump to the 480w or 360w option in
 the srcset, and download a file that is likely under 20KB instead of a 200KB 1200px file!
```